### PR TITLE
Eora labels from indices.zip

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ v0.5.1
 ***************************
 
 * small bugfix with version numbering
+* Eora uses labels from seperate file if not found in zip file
 
 ***************************
 v0.5.0

--- a/pymrio/tools/iodownloader.py
+++ b/pymrio/tools/iodownloader.py
@@ -479,6 +479,10 @@ def download_eora26(
         for yr in years
     ]
 
+    restricted_eora_urls.append(
+        "https://worldmrio.com/ComputationsM/Phase199/Loop082/simplified/indices.zip"
+    )
+
     downlog = MRIOMetaData._make_download_log(
         location=storage_folder,
         description="Download log for Eora",

--- a/pymrio/tools/ioparser.py
+++ b/pymrio/tools/ioparser.py
@@ -1859,9 +1859,26 @@ def parse_eora26(path, year=None, price="bp", country_names="eora"):
 
     if is_zip:
         zip_file = zipfile.ZipFile(eora_loc)
+        indices_file = None
+        for key, filename in eora_files.items():
+            if filename not in zip_file.namelist() and filename.startswith("labels"):
+                try:
+                    indices_loc = os.path.join(path, "indices.zip")
+                    indices_file = zipfile.ZipFile(indices_loc)
+                except:
+                    raise ValueError(
+                        f"{filename} is not available in the zip file and no indices.zip file is available in the directory provided"
+                    )
+
         eora_data = {
             key: pd.read_csv(
                 zip_file.open(filename),
+                sep=eora_sep,
+                header=None,
+            )
+            if filename in zip_file.namelist()
+            else pd.read_csv(
+                indices_file.open(filename),
                 sep=eora_sep,
                 header=None,
             )


### PR DESCRIPTION
Eora file for the year 2016 lacks the labels_VA.txt file, so I configured the parser so that if it doesn't find any of the labels files to use it from the indices.zip which I added to the Eora downloader to be downloaded by default 