### PR TITLE
Exio down fix

### DIFF
--- a/pymrio/tools/iodownloader.py
+++ b/pymrio/tools/iodownloader.py
@@ -39,8 +39,7 @@ EORA26_CONFIG = {
 }
 
 EXIOBASE3_CONFIG = {
-    "url_db_view": "https://doi.org/10.5281/zenodo.5589597",  # lastest version
-    # "url_db_view": "https://doi.org/10.5281/zenodo.3583070",  # version 3.8.1
+    "url_db_view": "https://doi.org/10.5281/zenodo.3583070",  # lastest version
     # "url_db_view": "https://doi.org/10.5281/zenodo.3583071",  # version 3.7
     # "url_db_view": "https://doi.org/10.5281/zenodo.4277368",  # version 3.8
     "url_db_content": "",
@@ -554,7 +553,7 @@ def download_exiobase3(
     years=None,
     system=None,
     overwrite_existing=False,
-    doi="10.5281/zenodo.5589597",
+    doi="10.5281/zenodo.3583070",
 ):
     """
     Downloads EXIOBASE 3 files from Zenodo

--- a/pymrio/tools/iodownloader.py
+++ b/pymrio/tools/iodownloader.py
@@ -43,7 +43,7 @@ EXIOBASE3_CONFIG = {
     # "url_db_view": "https://doi.org/10.5281/zenodo.3583071",  # version 3.7
     # "url_db_view": "https://doi.org/10.5281/zenodo.4277368",  # version 3.8
     "url_db_content": "",
-    "mrio_regex": r"https://zenodo.org/record/\d*/files/IOT_\d\d\d\d_[p,i]x[p,i].zip",
+    "mrio_regex": r"https://zenodo.org/records/\d*/files/IOT_\d\d\d\d_[p,i]x[p,i].zip",
     "requests_func": requests.get,
 }
 

--- a/pymrio/tools/iodownloader.py
+++ b/pymrio/tools/iodownloader.py
@@ -39,7 +39,8 @@ EORA26_CONFIG = {
 }
 
 EXIOBASE3_CONFIG = {
-    "url_db_view": "https://doi.org/10.5281/zenodo.3583070",  # lastest version
+    "url_db_view": "https://doi.org/10.5281/zenodo.5589597",  # lastest version
+    # "url_db_view": "https://doi.org/10.5281/zenodo.3583070",  # version 3.8.1
     # "url_db_view": "https://doi.org/10.5281/zenodo.3583071",  # version 3.7
     # "url_db_view": "https://doi.org/10.5281/zenodo.4277368",  # version 3.8
     "url_db_content": "",
@@ -553,7 +554,7 @@ def download_exiobase3(
     years=None,
     system=None,
     overwrite_existing=False,
-    doi="10.5281/zenodo.3583070",
+    doi="10.5281/zenodo.5589597",
 ):
     """
     Downloads EXIOBASE 3 files from Zenodo


### PR DESCRIPTION
Zenodo has changed the structure of the urls, instead of "zenodo.org/record/" it is now "zenodo.org/records/", so I updated the regex for exiobase