### PR TITLE
Fix SyntaxError warning in regexp after Python 3.12

### DIFF
--- a/pymrio/tools/ioutil.py
+++ b/pymrio/tools/ioutil.py
@@ -659,7 +659,7 @@ def filename_from_url(url):
         The extracted file name
 
     """
-    name = re.search("[^/\\&\?]+\.\w{2,7}(?=([\?&].*$|$))", url)
+    name = re.search("[^/\\&?]+\.\w{2,7}(?=([?&].*$|$))", url)
     return name.group()
 
 


### PR DESCRIPTION
Python 3.12 is stricter about regular expression: as the character `?` has no special meaning within squared brackets, escaping it is ambiguous.