### PR TITLE
Fixing FutureWarning due to groupby(... axis=1 ...)

### DIFF
--- a/pymrio/core/mriosystem.py
+++ b/pymrio/core/mriosystem.py
@@ -897,10 +897,10 @@ class Extension(BaseSystem):
 
         if Y_agg is None:
             try:
-                Y_agg = Y.groupby(level="region", axis=1, sort=False).sum()
+                Y_agg = Y.T.groupby(level="region", sort=False).sum().T
 
             except (AssertionError, KeyError):
-                Y_agg = Y.groupby(level=0, axis=1, sort=False).sum()
+                Y_agg = Y.T.groupby(level=0, sort=False).sum().T
 
         y_vec = Y.sum(axis=0)
 
@@ -953,9 +953,9 @@ class Extension(BaseSystem):
             # F_Y_agg = ioutil.agg_columns(
             # ext['F_Y'], self.get_Y_categories().size)
             try:
-                F_Y_agg = self.F_Y.groupby(level="region", axis=1, sort=False).sum()
+                F_Y_agg = self.F_Y.T.groupby(level="region", sort=False).sum().T
             except (AssertionError, KeyError):
-                F_Y_agg = self.F_Y.groupby(level=0, axis=1, sort=False).sum()
+                F_Y_agg = self.F_Y.T.groupby(level=0, sort=False).sum().T
 
         if (
             (self.D_cba is None)
@@ -981,34 +981,34 @@ class Extension(BaseSystem):
         ):
             try:
                 self.D_cba_reg = (
-                    self.D_cba.groupby(level="region", axis=1, sort=False).sum()
+                    self.D_cba.T.groupby(level="region", sort=False).sum().T
                     + F_Y_agg
                 )
             except (AssertionError, KeyError):
                 self.D_cba_reg = (
-                    self.D_cba.groupby(level=0, axis=1, sort=False).sum() + F_Y_agg
+                    self.D_cba.T.groupby(level=0, sort=False).sum().T + F_Y_agg
                 )
             try:
                 self.D_pba_reg = (
-                    self.D_pba.groupby(level="region", axis=1, sort=False).sum()
+                    self.D_pba.T.groupby(level="region", sort=False).sum().T
                     + F_Y_agg
                 )
             except (AssertionError, KeyError):
                 self.D_pba_reg = (
-                    self.D_pba.groupby(level=0, axis=1, sort=False).sum() + F_Y_agg
+                    self.D_pba.T.groupby(level=0, sort=False).sum().T + F_Y_agg
                 )
             try:
-                self.D_imp_reg = self.D_imp.groupby(
-                    level="region", axis=1, sort=False
-                ).sum()
+                self.D_imp_reg = self.D_imp.T.groupby(
+                    level="region", sort=False
+                ).sum().T
             except (AssertionError, KeyError):
-                self.D_imp_reg = self.D_imp.groupby(level=0, axis=1, sort=False).sum()
+                self.D_imp_reg = self.D_imp.T.groupby(level=0, sort=False).sum().T
             try:
-                self.D_exp_reg = self.D_exp.groupby(
-                    level="region", axis=1, sort=False
-                ).sum()
+                self.D_exp_reg = self.D_exp.T.groupby(
+                    level="region", sort=False
+                ).sum().T
             except (AssertionError, KeyError):
-                self.D_exp_reg = self.D_exp.groupby(level=0, axis=1, sort=False).sum()
+                self.D_exp_reg = self.D_exp.T.groupby(level=0, sort=False).sum().T
 
             logging.debug("{} - Accounts D for regions calculated".format(self.name))
 
@@ -2171,13 +2171,13 @@ class IOSystem(BaseSystem):
             _index_names = df.index.names
             _columns_names = df.columns.names
             if (type(df.columns[0]) is not tuple) and df.columns[0].lower() == "unit":
-                df = df.groupby(df.index, axis=0, sort=False).first()
+                df = df.groupby(df.index, sort=False).first()
             else:
                 df = (
-                    df.groupby(df.index, axis=0, sort=False)
+                    df.groupby(df.index, sort=False)
                     .sum()
-                    .groupby(df.columns, axis=1, sort=False)
-                    .sum()
+                    .T.groupby(df.columns, sort=False)
+                    .sum().T
                 )
 
             if type(df.index[0]) is tuple:

--- a/pymrio/tools/iomath.py
+++ b/pymrio/tools/iomath.py
@@ -607,18 +607,18 @@ def calc_gross_trade(
 
     level_spec_Z = "region" if "region" in Z.columns.names else 0
     level_spec_Y = "region" if "region" in Y.columns.names else 0
-    Z_trade_agg = Z_trade_blocks.groupby(axis=1, level=level_spec_Z, sort=False).agg(
+    Z_trade_agg = Z_trade_blocks.T.groupby(level=level_spec_Z, sort=False).agg(
         sum
-    )
-    Y_trade_agg = Y_trade_blocks.groupby(axis=1, level=level_spec_Y, sort=False).agg(
+    ).T
+    Y_trade_agg = Y_trade_blocks.T.groupby(level=level_spec_Y, sort=False).agg(
         sum
-    )
+    ).T
 
     x_bilat = Z_trade_agg + Y_trade_agg
 
     level_spec_x = "sector" if "sector" in x_bilat.index.names else 1
     gross_imports = pd.DataFrame(
-        x_bilat.groupby(axis=0, level=level_spec_x, sort=False)
+        x_bilat.groupby(level=level_spec_x, sort=False)
         .agg(sum)
         .stack()
         .swaplevel(),

--- a/pymrio/tools/ioparser.py
+++ b/pymrio/tools/ioparser.py
@@ -1672,23 +1672,23 @@ def parse_oecd(path, year=None):
 
         # aggregate rows
         Z.loc[co_name, :] = (
-            Z.loc[co_name, :] + Z.loc[agg_list, :].groupby(level="sector", axis=0).sum()
+            Z.loc[co_name, :] + Z.loc[agg_list, :].groupby(level="sector").sum()
         ).values
         Z = Z.drop(agg_list, axis=0)
         Y.loc[co_name, :] = (
-            Y.loc[co_name, :] + Y.loc[agg_list, :].groupby(level="sector", axis=0).sum()
+            Y.loc[co_name, :] + Y.loc[agg_list, :].groupby(level="sector").sum()
         ).values
         Y = Y.drop(agg_list, axis=0)
 
         # aggregate columns
         Z.loc[:, co_name] = (
-            Z.loc[:, co_name] + Z.loc[:, agg_list].groupby(level="sector", axis=1).sum()
+            Z.loc[:, co_name] + Z.loc[:, agg_list].T.groupby(level="sector").sum().T
         ).values
         Z = Z.drop(agg_list, axis=1)
 
         F_factor_input.loc[:, co_name] = (
             F_factor_input.loc[:, co_name]
-            + F_factor_input.loc[:, agg_list].groupby(level="sector", axis=1).sum()
+            + F_factor_input.loc[:, agg_list].T.groupby(level="sector").sum().T
         ).values
         F_factor_input = F_factor_input.drop(agg_list, axis=1)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -419,7 +419,7 @@ def test_direct_account_calc(fix_testmrio):
 
     new = orig.copy().rename_regions({"reg3": "ll", "reg4": "aa"})
 
-    Y_agg = new.Y.groupby(axis=1, level="region", sort=False).agg(sum)
+    Y_agg = new.Y.T.groupby(level="region", sort=False).agg(sum).T
 
     (D_cba, D_pba, D_imp, D_exp) = pymrio.calc_accounts(new.emissions.S, new.L, Y_agg)
 

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -719,7 +719,7 @@ def test_calc_accounts_MRIO(td_small_MRIO):
     nD_cba, nD_pba, nD_imp, nD_exp = calc_accounts(
         td_small_MRIO.S,
         td_small_MRIO.L,
-        td_small_MRIO.Y.groupby(level="region", axis=1, sort=False).sum(),
+        td_small_MRIO.Y.T.groupby(level="region", sort=False).sum().T,
     )
     # test all
 


### PR DESCRIPTION
Solving the following warning as suggested by Pandas.
- FutureWarning: DataFrame.groupby with axis=1 is deprecated. Do `frame.T.groupby(...)` without axis instead